### PR TITLE
Fix display of document table

### DIFF
--- a/src/pages/documents.tsx
+++ b/src/pages/documents.tsx
@@ -176,7 +176,7 @@ const Index: React.FC = () => {
     }
 
     return currentDocuments
-      .filter((doc) => doc.status === 'success')
+      .filter((doc) => doc.ingestion_status === 'success')
       .map((doc) => (
         <tr key={doc.id}>
           <td className="px-4 py-2 text-white">

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,8 @@ export interface DocumentInfoType {
   title: string;
   version: string;
   size_in_bytes: number;
-  status: string;
+  ingestion_status: string;
+  restructuring_status: string;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
The `status` field in the API was split into two new fields: `ingestion_status` and `restructuring_status`. I modified the code to use the former.

Without this fix, the table would never display rows.