### PR TITLE
Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 /assets
+node_modules


### PR DESCRIPTION
exclude node modules


docker build fail due to node_modules being sync from host machine to docker